### PR TITLE
minor fixes

### DIFF
--- a/c_src/_web.c
+++ b/c_src/_web.c
@@ -14,6 +14,10 @@
 #include "brightness_maps.h"
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 static char module_docstring[] =
     "This module is used to calcuate the areas of geometric shapes";
 static char web_docstring[] =

--- a/c_src/_web.c
+++ b/c_src/_web.c
@@ -482,12 +482,12 @@ static PyObject *web_calc_substellar(PyObject *self, PyObject *args)
 static PyObject *web_lightcurve(PyObject *self, PyObject *args)
 {
 
-    int n_layers, bright_type, n_star;
+    int n_layers, bright_type, n_star, eclipse;
     double tc,per,a,inc,ecc,omega,a_rs,rp,p_u1,p_u2;
     PyObject *t_obj,*bright_obj,*teff_obj,*flux_obj;
 
     /* Parse the input tuple */
-    if (!PyArg_ParseTuple(args, "iOddddddddddiOOOi", &n_layers,&t_obj,&tc,&per,&a,&inc,&ecc,&omega,&a_rs,&rp,&p_u1,&p_u2,&bright_type,&bright_obj,&teff_obj,&flux_obj,&n_star))
+    if (!PyArg_ParseTuple(args, "iOddddddddddiOOOii", &n_layers,&t_obj,&tc,&per,&a,&inc,&ecc,&omega,&a_rs,&rp,&p_u1,&p_u2,&bright_type,&bright_obj,&teff_obj,&flux_obj,&n_star,&eclipse))
         return NULL;
 
     PyObject *bright_array = PyArray_FROM_OTF(bright_obj, NPY_DOUBLE, NPY_IN_ARRAY);
@@ -525,7 +525,7 @@ static PyObject *web_lightcurve(PyObject *self, PyObject *args)
 
     /* Call the external C function to compute the area. */
 
-    double *output = lightcurve(n_layers,N,t2,tc,per,a,inc,ecc,omega,a_rs,rp,p_u1,p_u2,bright_type,brightness_params,star_teff,star_flux,n_star);
+    double *output = lightcurve(n_layers,N,t2,tc,per,a,inc,ecc,omega,a_rs,rp,p_u1,p_u2,bright_type,brightness_params,star_teff,star_flux,n_star, eclipse);
 
     PyObject *pylist = Convert_Big_Array(output,N);
 

--- a/c_src/areas.c
+++ b/c_src/areas.c
@@ -5,6 +5,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 double two_inner_two_edges_a(double *c1,double *c2,double *e1,double *e2,double *e3,double *e4,double r_inner,double r_outer,double x2,double y2,double r2,double total_area){
     double a_1,a_2,a_3,a_4,a_5,a_6,area;
     double *first_c, *second_c;

--- a/c_src/blocked.c
+++ b/c_src/blocked.c
@@ -7,6 +7,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
 
 double blocked(double **planet, int n_layers, double x2, double y2, double r2){
     double x1,y1,r1;

--- a/c_src/brightness_maps.c
+++ b/c_src/brightness_maps.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 double Hotspot_b(double la, double lo,double la0, double lo0,double p_b,double spot_b,double size, int make_grid ,double theta1, double theta2, double r1, double r2, double lambda0, double phi0){
 
     double r_mid;

--- a/c_src/ephemeris.c
+++ b/c_src/ephemeris.c
@@ -3,6 +3,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
 
 double *separation_of_centers(double t, double tc, double per, double a, double inc, double ecc, double omega, double a_rs, double Ratio){
 	// based on equations in Winn 2010 (chapter of sara seager book same year)

--- a/c_src/generate.c
+++ b/c_src/generate.c
@@ -7,6 +7,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 void map_model(double **planet,int n_layers,double lambda0, double phi0, double u1, double u2,int brightness_model,double *brightness_params,double **bb_g,double star_bright){
     double point_T,mu,p_t_bright;
     double l1,l2,R_mid,theta_mid,mid_x,mid_y;

--- a/c_src/intersection.c
+++ b/c_src/intersection.c
@@ -3,6 +3,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 double *circle_intersect(double x1,double y1,double r1,double x2,double y2,double r2){
     double d,a,x_first,y_first,x_second,y_second,theta_first,theta_second;
     

--- a/c_src/orthographic.c
+++ b/c_src/orthographic.c
@@ -3,6 +3,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
 
 double *ortho_to_cart(double R, double lambda, double phi, double lambda0, double phi0){
 	double x,y,cosc;

--- a/c_src/segment.c
+++ b/c_src/segment.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 double find_segment_area(double *c1x, double *c2x,double x2,double y2,double r2){
     double area,theta1,theta2,theta;
 

--- a/c_src/web.c
+++ b/c_src/web.c
@@ -12,7 +12,7 @@
     #define M_PI 3.14159265358979323846
 #endif
 
-double *lightcurve(int n_layers, int n_points, double *t, double tc, double per, double a, double inc, double ecc, double omega, double a_rs, double rp,double u1, double u2,int brightness_model,double *brightness_params,double *stellar_teffs,double *stellar_fluxes,int nstars){
+double *lightcurve(int n_layers, int n_points, double *t, double tc, double per, double a, double inc, double ecc, double omega, double a_rs, double rp,double u1, double u2,int brightness_model,double *brightness_params,double *stellar_teffs,double *stellar_fluxes,int nstars, int eclipse){
     int n,j;
     double phase,lambda0,phi0;
     double *coords;
@@ -104,7 +104,7 @@ double *lightcurve(int n_layers, int n_points, double *t, double tc, double per,
             p_bright = p_bright + planet[j][16]*planet[j][15];
         }
 
-        if(coords[2] < 0){
+        if(coords[2] < 0 && eclipse == 1){
             p_blocked = blocked(planet,n_layers,coords[0],coords[1],r2);
         }
         else{
@@ -112,6 +112,7 @@ double *lightcurve(int n_layers, int n_points, double *t, double tc, double per,
             p_blocked = 0.0;
         }
         output[n] = (star_bright + p_bright - p_blocked)/star_bright;
+//        output[n] = p_bright/star_bright;
 
         free(coords);
     }

--- a/c_src/web.c
+++ b/c_src/web.c
@@ -8,6 +8,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 double *lightcurve(int n_layers, int n_points, double *t, double tc, double per, double a, double inc, double ecc, double omega, double a_rs, double rp,double u1, double u2,int brightness_model,double *brightness_params,double *stellar_teffs,double *stellar_fluxes,int nstars){
     int n,j;
     double phase,lambda0,phi0;

--- a/c_src/web.h
+++ b/c_src/web.h
@@ -1,4 +1,4 @@
-double *lightcurve(int n_layers, int n_points, double *t, double tc, double per, double a, double inc, double ecc, double omega, double r_s, double r2,double u1, double u2,int brightness_model,double* brightness_params,double* stellar_teff,double* stellar_flux,int nstars);
+double *lightcurve(int n_layers, int n_points, double *t, double tc, double per, double a, double inc, double ecc, double omega, double r_s, double r2,double u1, double u2,int brightness_model,double* brightness_params,double* stellar_teff,double* stellar_flux,int nstars, int eclipse);
 double *call_blocked(int n_layers, int n_points, double *x2, double *y2, double r2);
 double calc_phase(double t, double t0, double per);
 double *calc_substellar(double phase, double *coords);

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import numpy.distutils.misc_util
 import numpy as np
 
 _web = Extension("spiderman._web",["c_src/_web.c","c_src/heron.c","c_src/segment.c","c_src/areas.c","c_src/intersection.c","c_src/generate.c","c_src/blocked.c","c_src/util.c","c_src/pyutil.c","c_src/web.c","c_src/orthographic.c","c_src/ephemeris.c","c_src/blackbody.c","c_src/spline.c","c_src/brightness_maps.c","c_src/legendre_polynomial.c"
-])
+], extra_compile_args = ["-std=c99"])
 
 setup(	name='spiderman-package', 
 	version="0.3.1",

--- a/spiderman/params.py
+++ b/spiderman/params.py
@@ -20,6 +20,7 @@ class ModelParams(object):
 		self.rp= None				# Planet radius as a fraction of stellar radius [-]
 		self.p_u1= None				# **PLANETARY** limb darkening coefficients [-]
 		self.p_u2= None				# **PLANETARY** limb darkening coefficients [-]
+		self.eclipse = True			# specifies whether to include the drop in flux due to the eclipse
 
 		if brightness_model == 'uniform brightness':
 			self.n_layers = 1		# The default resolution for the grid

--- a/spiderman/web.py
+++ b/spiderman/web.py
@@ -74,7 +74,7 @@ def lightcurve(t,spider_params,stellar_grid=False):
 		teffs = []
 		totals = []
 
-	return _web.lightcurve(spider_params.n_layers,t,spider_params.t0,spider_params.per,spider_params.a_abs,spider_params.inc,spider_params.ecc,spider_params.w,spider_params.a,spider_params.rp,spider_params.p_u1,spider_params.p_u2,spider_params.brightness_type,brightness_params,teffs,totals,len(totals))
+	return _web.lightcurve(spider_params.n_layers,t,spider_params.t0,spider_params.per,spider_params.a_abs,spider_params.inc,spider_params.ecc,spider_params.w,spider_params.a,spider_params.rp,spider_params.p_u1,spider_params.p_u2,spider_params.brightness_type,brightness_params,teffs,totals,len(totals), spider_params.eclipse)
 
 def bb_grid(l1,l2,T_start,T_end,n_temps,n_segments):
 	temps, fluxes, deriv = _web.bb_grid(l1,l2,T_start,T_end,n_temps,n_segments)


### PR DESCRIPTION
hey, just updating to add a new compiler flag and definitions of M_PI to the *.c files (this is needed to compile on some systems)

I also added the option to show the eclipse. The default is to show the eclipse, but when "params.eclipse" is set to False, the lightcurve() returns the planet/star flux as if there were no eclipse. This is useful for calculating the expected dayside spectrum.