### PR TITLE
add option to use custom stellar model

### DIFF
--- a/docs/stellar_models.rst
+++ b/docs/stellar_models.rst
@@ -1,26 +1,30 @@
 Stellar models
 =====================================
 
-In some circumstances, you might want to attempt to directly determine the absolute brightness temperature of the planet, instead of just the brightness relative to the star. Some physical models may require you to do this, for example the zhang and showman (2017) model.
+In some circumstances, you might want to attempt to directly determine the absolute brightness temperature of the planet, instead of just the brightness relative to the star. Some physical models may require you to do this, for example the Zhang and Showman (2017) model.
 
-To do this you need the absolute brightnes of the star - don't worry, spiderman has you covered!
+To do this you need the absolute brightness of the star - don't worry, spiderman has you covered! There are three options for stellar models that can be specified when the model parameters are initialized:
 
-All models that require thermal information take the stellar effective temperature as a model parameter, and the bandpass of the observations must also be specified like so:
+.. code-block:: python
+        spider_params = spiderman.ModelParams(brightness_model =  'zhang', stellar_model = stellar_model)
+
+where options for the stellar model include "blackbody" (the default), "PHOENIX", and "path_to_model" (a user-specified spectrum).
+
+Blackbody model
+---------------
+At the most basic level, you can assume that the spectrum of the star is simply blackbody with the effective temperature of the star.  Users specify the effective temperature as a model parameter, and the bandpass of the observations must also be specified like so:
 
 .. code-block:: python
 
-	spider_params.l1 = 4520		# The stellar effective temperature in K
+	spider_params.T_s = 4520	# The stellar effective temperature in K
 	spider_params.l1 = 1.1e-6	# The starting wavelength in meters
 	spider_params.l2 = 1.7e-6	# The ending wavelength in meters
 
-At the most basic level, you can assume that the spectrum of the star is simply blackbody with the effective temperature of the star. This is the default mode for spiderman. Over very wide bandpasses this will be good enough, but for narrower spectral ranges this could introduce significant errors, particularly for cooler stars with deep molecular absorption bands.
+Blackbody stellar models are the default mode for spiderman. Over very wide bandpasses this will be good enough, but for narrower spectral ranges this could introduce significant errors, particularly for cooler stars with deep molecular absorption bands.
 
-Of course, a better option would be to use realistic stellar spectra to determine the stellar flux - spiderman can do this as well, but it requires an external library of spectra, that are specified using the .spidermanrc file:
-
-Using the spidermanrc file
---------------------------
-
-a .spidermanrc file is used to give global parameters to the code. At present, the only setting needed is the location of model stellar spectra, but more customisation options may be added in future updates.
+PHOENIX model
+-------------
+A more physically realistic option is to use model stellar spectra to determine the stellar flux - spiderman can do this as well, but it requires downloading an external library of spectra. The path to the library is specified using the .spidermanrc file, as follows:
 
 .. note:: Currently, the only supported model spectra are the R=10000 PHOENIX models from this page: ftp://phoenix.astro.physik.uni-goettingen.de/MedResFITS/R10000FITS/PHOENIX-ACES-AGSS-COND-2011_R10000FITS_Z-0.0.zip
 
@@ -28,24 +32,41 @@ Download and unpack the model spectra, then make a ".spidermanrc" file in your h
 
 PHOENIX_DIR : /path/to/PHOENIX/
 
-A spidermanrc file is not required - SPIDERMAN will run happily without a spidermanrc file and just calculate blackbodies for the stellar atmosphere instead.
+As for the blackbody, users specify the wavelength limits for the bandpass and the effective temperature of the star. 
 
-In future releases the spidermanrc file may contain additional global parameters.
+.. code-block:: python
+
+	spider_params = spiderman.ModelParams(brightness_model = 'zhang', stellar_model = 'PHOENIX')
+	spider_params.l1 = 1.1e-6	# The starting wavelength in meters
+	spider_params.l2 = 1.7e-6	# The ending wavelength in meters
+	spider_params.T_s = 4520	# The stellar effective temperature in K
+
+        .. warning:: spiderman currently only interpolates the stellar flux in 1D (Temperature) and assumes by default that the star is a dwarf with logg 4.5 - 2d interpolation with logg will be included in a future update
+
+Custom stellar spectrum
+-----------------------
+It is also possible to use your own stellar spectrum. To do this, simply specify the path to the spectrum when you initialize the ModelParams class:
+
+.. code-block:: python
+
+	web_p = spiderman.ModelParams(brightness_model = 'zhang', stellar_model = 'path_to_model')
+
+where the spectrum is saved in a file called 'path_to_model'. This file must be formatted in two columns, where column (1) has the wavelength in meters and column (2) has the stellar flux in units of W/m^3/sr.
+
 
 Precalculating grids of models
 -------------------------------
 
-In order to speed up computation, spiderman will automatically generate a grid of the *summed stellar flux* in the defined bandpass as a function of stellar effective temperature, when calculating the flux of the star given its effective temperature spiderman will then use this grid to interpolate on to find the appropriate temperature, to a high level of precision.
+In order to speed up computation, spiderman can automatically generate a grid of the *summed stellar flux* in the defined bandpass as a function of stellar effective temperature, when calculating the flux of the star given its effective temperature spiderman will then use this grid to interpolate on to find the appropriate temperature, to a high level of precision.
 
-.. warning:: spiderman currently only interpolates the stellar flux in 1D (Temperature) and assumes by default that the star is a dwarf with logg 4.5 - 2d interpolation with logg will be included in a future update
 
 If you a running an MCMC, or another numerical method that requires you to call spiderman many thousands of times, especially if you are including the stellar temperature as a model parameter, you should *precalculate* this grid before begining the model fit and pass it to spiderman to increase the efficiency. This can be done very easily with the stellar_grid module:
 
 .. code-block:: python
 
-	stellar_grid = spiderman.stellar_grid.gen_grid(l1,l2,logg=4.5)
+	stellar_grid = spiderman.stellar_grid.gen_grid(l1,l2,logg=4.5, stellar_model = stellar_model)
 
-Where l1 and l2 are the begining and end of the spectral window in meters, and logg is the cgs surface gravity of the star. The stellar_grid object is then passed to spiderman for every light curve generation instance, e.g.
+Where l1 and l2 are the begining and end of the spectral window in meters, logg is the cgs surface gravity of the star, and stellar_model is the model stellar spectrum ("blackbody", "PHOENIX", or "path_to_model"). The stellar_grid object is then passed to spiderman for every light curve generation instance, e.g.
 
 .. code-block:: python
 

--- a/spiderman/params.py
+++ b/spiderman/params.py
@@ -21,7 +21,7 @@ class MultiModelParams(object):
 
 
 class ModelParams(object):
-	def __init__(self,brightness_model='zhang',thermal=False, nearest=None):
+	def __init__(self,brightness_model='zhang',thermal=False, nearest=None, stellar_model = 'blackbody'):
 
 		self.n_layers = 5			# The default resolution for the grid
 
@@ -37,9 +37,9 @@ class ModelParams(object):
 		self.p_u2= None				# **PLANETARY** limb darkening coefficients [-]
 		self.eclipse = True			# specifies whether to include the drop in flux due to the eclipse
 		self.filter = False			# Can use an external response file.
+                self.stellar_model = stellar_model                # Specifies which stellar model to use (blackbody, PHOENIX, custom)
 		self.grid = [[],[],[[]]]			# needed in case the "direct read" method is wanted
 		self.nearest = nearest         # used for choosing which interpolation model to use - default is spline
-
 
 		if brightness_model == 'uniform brightness':
 			self.n_layers = 1		# The default resolution for the grid
@@ -373,7 +373,7 @@ class ModelParams(object):
 
 		if self.thermal == True:
 			if stellar_grid == False:
-				star_grid = sp.stellar_grid.gen_grid(self.l1,self.l2,logg=4.5,response=self.filter)
+				star_grid = sp.stellar_grid.gen_grid(self.l1,self.l2,logg=4.5,response=self.filter, stellar_model = self.stellar_model)
 				teffs = star_grid[0]
 				totals = star_grid[1]
 			else:
@@ -513,7 +513,7 @@ class ModelParams(object):
 
 		if self.thermal == True:
 			if stellar_grid == False:
-				stellar_grid = sp.stellar_grid.gen_grid(self.l1,self.l2,logg=4.5,response=self.filter)
+				stellar_grid = sp.stellar_grid.gen_grid(self.l1,self.l2,logg=4.5,response=self.filter, stellar_model = self.stellar_model)
 				teffs = stellar_grid[0]
 				totals = stellar_grid[1]
 			else:

--- a/spiderman/web.py
+++ b/spiderman/web.py
@@ -40,18 +40,15 @@ def circle_intersect(x1,y1,r1,x2,y2,r2):
 def line_intersect(x1,y1,x2,y2,r2):
 	return _web.line_intersect(x1,y1,x2,y2,r2)
 
-def generate_planet(spider_params,t,use_phase=False,stellar_grid=False,logg=4.5):
-
-
+def generate_planet(spider_params,t,use_phase=False,stellar_grid=False,logg=4.5, stellar_model = "blackbody"):
 	if use_phase == True:
 		t = spider_params.t0 + spider_params.per*t
 	brightness_params = spider_params.format_bright_params()
 
-
 	if spider_params.thermal == True:
 		if ((spider_params.brightness_type == 9) or (spider_params.brightness_type == 10)):
 			if stellar_grid == False:
-				star_grid = sp.stellar_grid.gen_grid(spider_params.l1,spider_params.l2,logg=logg,response=spider_params.filter)
+				star_grid = sp.stellar_grid.gen_grid(spider_params.l1,spider_params.l2,logg=logg,response=spider_params.filter, stellar_model = stellar_model)
 				teffs = star_grid[0]
 				totals = star_grid[1]
 			else:
@@ -91,12 +88,11 @@ def lightcurve(t,spider_params,stellar_grid=False,logg=4.5,use_phase=False):
 	if use_phase == True:
 		t = spider_params.t0 + spider_params.per*t
 
-
 	brightness_params = spider_params.format_bright_params()
 
 	if spider_params.thermal == True:
 		if stellar_grid == False:
-			star_grid = sp.stellar_grid.gen_grid(spider_params.l1,spider_params.l2,logg=logg,response=spider_params.filter)
+			star_grid = sp.stellar_grid.gen_grid(spider_params.l1,spider_params.l2,logg=logg,response=spider_params.filter, stellar_model = spider_params.stellar_model)
 			teffs = star_grid[0]
 			totals = star_grid[1]
 		else:


### PR DESCRIPTION
I added the option to use a custom stellar spectrum, and I added a flag to the params object to specify which stellar model is being used (blackbody, PHOENIX, or custom).

I also updated the stellar models section in the docs.