### PR TITLE
Fixing broken spidermanrc reading for Ubuntu

### DIFF
--- a/spiderman/__init__.py
+++ b/spiderman/__init__.py
@@ -10,7 +10,7 @@ class RcParams(object):
 			print('looking for spidermanrc file at '+param_file)
 			for line in open(param_file):
 				key = line.split(':')[0].replace(' ','')
-				cval = line.split(':')[1].replace(' ','')
+				cval = line.split(':')[1].replace(' ','').replace('\n','')
 				self.dict[key] = cval
 			RcParams.read = True
 		except:


### PR DESCRIPTION
Running Ubuntu 16.04, `spiderman/__init__.py` picks up a \n from the .spidermanrc file when none is present. This is fixed with a simple change of 
`cval = line.split(':')[1].replace(' ','')`
to
`cval = line.split(':')[1].replace(' ','').replace('\n','')`
on line 13 of `__init__.py`

Someone running Mac and/or Windows should check that this doesn't break the reading-in of phoenix models for them