### PR TITLE
fixed filter memory leak

### DIFF
--- a/c_src/_web.c
+++ b/c_src/_web.c
@@ -713,6 +713,13 @@ static PyObject *web_lightcurve(PyObject *self, PyObject *args)
     Py_DECREF(flux_array);
     Py_DECREF(bright_array);
 
+    /* Fixes memory leak */
+    Py_DECREF(response_array);
+    Py_DECREF(wvl_array);
+    for (int i = 0; i < 2; ++i) {
+        free(wvl_grid[i]);
+    }
+
     return pylist;
 }
 


### PR DESCRIPTION
Hi Tom, 
I ran across a memory leak when using a filter. Freeing the memory with the few lines I added in __web.c_, fixed it for me.
Cheers,
Sebastian