### PR TITLE
Patching code for python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(	name='spiderman-package',
 	url = 'https://github.com/tomlouden/spiderman',
 	download_url = 'https://github.com/tomlouden/spiderman/tarball/1.0.2',
 	packages =['spiderman'],
-	license = ['GNU GPLv3'],
+	license = 'GNU GPLv3',
 	description ='Fast secondary eclipse and phase curve modeling',
 	classifiers = [
 		'Development Status :: 4 - Beta',

--- a/spiderman/plot.py
+++ b/spiderman/plot.py
@@ -3,7 +3,7 @@ import matplotlib as mpl
 import spiderman as sp
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib._png import read_png
+from matplotlib.pyplot import imread as read_png
 from matplotlib.offsetbox import TextArea, DrawingArea, OffsetImage, \
     AnnotationBbox
 import matplotlib.patches as patches

--- a/spiderman/stellar_grid.py
+++ b/spiderman/stellar_grid.py
@@ -79,7 +79,7 @@ def gen_grid(l1,l2,logg=4.5, response = False, stellar_model = "blackbody", verb
 def sum_flux(wvl,flux,l1,l2,filter=False):
 
 
-    mask = [(wvl > l1) & (wvl < l2)]
+    mask = (wvl > l1) & (wvl < l2)
 
     diff = np.diff(wvl)
     diff = (np.append(diff,diff[-1:]) + np.append(diff[1:],diff[-2:]))/2


### PR DESCRIPTION
I am looking at adding spiderman as an accepted model type in [Eureka](https://github.com/kevin218/Eureka), but I encountered several issues installing and running spiderman. This PR includes the changes I needed to make in order to get spiderman installed and running on my Intel MacOS 12.6 running python 3.9.7.

1. I had to remove the brackets around the license kwarg to the setup function in setup.py as setuptools tries to run split on what it assumes is a string which fails if license is a list.
2. matplotlib._png is no longer present, but matplotlib.pyplot.imread does exist and should do the trick
3. The mask variable in the stellar_grid.sum_flux function had been made a list containing an array which made it 2 dimensional (1,1000) which broken when doing `diff = diff[mask]` as diff is only 1 dimensional

Spiderman now works for me, but I don't get the same values that are outputted on https://spiderman.readthedocs.io/en/latest/plotting.html. The two printed values on that page are 0.00045781826310942186 and 7.03802421799e+20 while I get 0.0005302903777573142 and 7.118960968189555e+22 even though I copy-pasted the exact commands on that page. The first plot I get is also not exactly the same shape as https://spiderman.readthedocs.io/en/latest/_images/simple_spectrum.png and instead has a slight upward curvature instead of downward curvature. Perhaps the docs values and plots are just out-of-date and do not represent the values one should expect with the current version of the code after some fixes or improvements?